### PR TITLE
fixed gaul code type

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -92,7 +92,7 @@
           {
             "name": "GAUL",
             "description": "Global Administrative Unit Layers from the Food and Agriculture Organization",
-            "type": "integer"
+            "type": "string"
           },
           {
             "name": "IOC",


### PR DESCRIPTION
Based on this commit - https://github.com/datasets/country-codes/commit/95a5729f1580dc4a66017d9f8fa58ccc9b623e72 - GAUL code is a string, not an integer.