### PR TITLE
remove trailing comma in sources section

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -34,7 +34,7 @@
     {
       "name": "US Securities and Exchange Commission",
       "web": "https://www.sec.gov/edgar/searchedgar/edgarstatecodes.htm"
-    },
+    }
   ],
   "resources": [
     {


### PR DESCRIPTION
This is breaking download with dpm.
JSON.parse throws the following error on `install`:

```
undefined:38
  ],
  ^

SyntaxError: Unexpected token ]
    at Object.parse (native)
    at Request._callback (lib/node_modules/datapackage/lib/index.js:171:21)
```