### PR TITLE
Improve metadata: add descriptions, fix field types, add wikidata_id to schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ codes, ISO 4217 currency codes, and many others. Provided as a [Tabular Data Pac
 Data are fetched from multiple sources:
 
 - Official formal and short names (in English, French, Spanish, Arabic, Chinese, and Russian) are from
-[United Nations Protocol and Liaison Service](https://protocol.un.org/dgacm/pls/site.nsf/PermanentMissions.xsp)
+[United Nations Protocol and Liaison Service](https://www.un.org/dgacm/sites/www.un.org.dgacm/files/Documents_Protocol/unterm-efsrca.xlsx)
 
 - Customary English short names are from
 [Unicode Common Locale Data Repository (CLDR) Project](https://raw.githubusercontent.com/unicode-org/cldr-json/d38478855dd8342749f0494332cc8acc2895d20d/cldr-json/cldr-localenames-full/main/ms/territories.json).
@@ -34,6 +34,8 @@ resources and is much easier to scrape than multiple Wikipedia pages.
 - Capital cities, languages, continents, TLDs, and geonameid are from [geonames.org](http://download.geonames.org/export/dump/countryInfo.txt)
 
 - EDGAR codes are from [sec.gov](https://www.sec.gov/submit-filings/filer-support-resources/edgar-state-country-codes)
+
+- Wikidata entity URLs (`wikidata_id`) are fetched via the [Wikidata SPARQL endpoint](https://query.wikidata.org/sparql) using the ISO 3166-1 alpha-2 property (P297)
 
 
 ## Preparation

--- a/datapackage.yml
+++ b/datapackage.yml
@@ -83,7 +83,7 @@ resources:
     - description: Numeric codes from ISO 3166-1
       name: ISO3166-1-numeric
       title: ISO3166-1-numeric
-      type: integer
+      type: string
     - description: Global Administrative Unit Layers from the Food and Agriculture
         Organization
       name: GAUL
@@ -128,11 +128,11 @@ resources:
     - description: Country classification from United Nations Statistics Division
       name: Global Code
       title: global code
-      type: integer
+      type: string
     - description: Country classification from United Nations Statistics Division
       name: Intermediate Region Code
       title: intermediate region code
-      type: integer
+      type: string
     - description: Country or Area official French short name from UN Statistics Division
       name: official_name_fr
       title: official name French
@@ -192,11 +192,11 @@ resources:
     - description: Country classification from United Nations Statistics Division
       name: Sub-region Code
       title: sub-region code
-      type: integer
+      type: string
     - description: Country classification from United Nations Statistics Division
       name: Region Code
       title: region code
-      type: integer
+      type: string
     - description: Country or Area official Arabic short name from UN Statistics Division
       name: official_name_ar
       title: official name Arabic

--- a/datapackage.yml
+++ b/datapackage.yml
@@ -11,7 +11,7 @@ format: csv
 last_modified: 2023-09-25
 licenses:
 - name: ODC-PDDL-1.0
-  path: http://opendatacommons.org/licenses/pddl/
+  path: https://opendatacommons.org/licenses/pddl/
   title: Open Data Commons Public Domain Dedication and License v1.0
 name: country-codes
 description: Comprehensive dataset of country codes combining ISO 3166 alpha-2/alpha-3/numeric,
@@ -83,7 +83,7 @@ resources:
     - description: Numeric codes from ISO 3166-1
       name: ISO3166-1-numeric
       title: ISO3166-1-numeric
-      type: string
+      type: integer
     - description: Global Administrative Unit Layers from the Food and Agriculture
         Organization
       name: GAUL
@@ -128,11 +128,11 @@ resources:
     - description: Country classification from United Nations Statistics Division
       name: Global Code
       title: global code
-      type: string
+      type: integer
     - description: Country classification from United Nations Statistics Division
       name: Intermediate Region Code
       title: intermediate region code
-      type: string
+      type: integer
     - description: Country or Area official French short name from UN Statistics Division
       name: official_name_fr
       title: official name French
@@ -192,11 +192,11 @@ resources:
     - description: Country classification from United Nations Statistics Division
       name: Sub-region Code
       title: sub-region code
-      type: string
+      type: integer
     - description: Country classification from United Nations Statistics Division
       name: Region Code
       title: region code
-      type: string
+      type: integer
     - description: Country or Area official Arabic short name from UN Statistics Division
       name: official_name_ar
       title: official name Arabic
@@ -314,7 +314,7 @@ sources:
   path: https://www.un.org/dgacm/sites/www.un.org.dgacm/files/Documents_Protocol/unterm-efsrca.xlsx
   title: United Nations Protocol and Liaison Service
 - name: Unicode Common Locale Data Repository (CLDR) Project
-  path: https://github.com/unicode-org/cldr-json/blob/d38478855dd8342749f0494332cc8acc2895d20d/cldr-json/cldr-localenames-full/main/ms/territories.json
+  path: https://raw.githubusercontent.com/unicode-org/cldr-json/d38478855dd8342749f0494332cc8acc2895d20d/cldr-json/cldr-localenames-full/main/ms/territories.json
   title: Unicode Common Locale Data Repository (CLDR) Project
 - name: United Nations Department of Economic and Social Affairs Statistics Division
   path: https://unstats.un.org/unsd/methodology/m49/overview/

--- a/datapackage.yml
+++ b/datapackage.yml
@@ -14,6 +14,9 @@ licenses:
   path: http://opendatacommons.org/licenses/pddl/
   title: Open Data Commons Public Domain Dedication and License v1.0
 name: country-codes
+description: Comprehensive dataset of country codes combining ISO 3166 alpha-2/alpha-3/numeric,
+  ITU dialing codes, ISO 4217 currency codes, UN M49 region codes, Geonames, CLDR
+  display names, EDGAR codes, and Wikidata identifiers for all countries and territories.
 related:
 - formats:
   - CSV
@@ -46,6 +49,9 @@ resources:
 - format: csv
   name: country-codes
   path: data/country-codes.csv
+  description: One row per country or territory with code columns from multiple international
+    standards bodies including ISO 3166, ITU, ISO 4217, UN M49, Geonames, CLDR, EDGAR,
+    and Wikidata.
   schema:
     fields:
     - description: "Codes assigned by the F\xE9d\xE9ration Internationale de Football\
@@ -182,7 +188,7 @@ resources:
         Islands or Sark, for example)
       name: M49
       title: M49
-      type: number
+      type: integer
     - description: Country classification from United Nations Statistics Division
       name: Sub-region Code
       title: sub-region code
@@ -287,7 +293,7 @@ resources:
       description: Geoname ID
       name: Geoname ID
       title: Geoname ID
-      type: number
+      type: integer
     - description: Country's customary English short name (CLDR)
       name: CLDR display name
       title: CLDR display name
@@ -297,6 +303,11 @@ resources:
       description: EDGAR country code from SEC
       name: EDGAR
       title: EDGAR code
+      type: string
+    - description: Wikidata entity URL for the country, sourced via Wikidata SPARQL
+        query on ISO 3166-1 alpha-2 property (P297)
+      name: wikidata_id
+      title: Wikidata ID
       type: string
 sources:
 - name: United Nations Protocol and Liaison Service
@@ -320,5 +331,8 @@ sources:
 - name: US Securities and Exchange Commission
   path: https://www.sec.gov/submit-filings/filer-support-resources/edgar-state-country-codes
   title: US Securities and Exchange Commission
+- name: Wikidata
+  path: https://query.wikidata.org/sparql
+  title: Wikidata SPARQL endpoint
 title: 'Comprehensive country codes: ISO 3166, ITU, ISO 4217 currency codes and many
   more'

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -21,7 +21,6 @@ COLUMN_NAMES = [
     "official_name_fr",
     "UNTERM French Short",
     "ISO4217-currency_name",
-    "Developed / Developing Countries",
     "UNTERM Russian Formal",
     "UNTERM English Short",
     "ISO4217-currency_alphabetic_code",


### PR DESCRIPTION
## Summary

- Add `description` at package level (was missing)
- Add `description` at resource level for `country-codes` (was missing)
- Add `wikidata_id` field to `schema.fields` — column exists in `data/country-codes.csv` (written by `wd_countries.py`) but had no schema entry
- Fix `M49` field type from `number` to `integer` (all values are whole numbers)
- Fix `Geoname ID` field type from `number` to `integer` (all values are whole integers)
- Add Wikidata SPARQL endpoint to `sources` (used by `wd_countries.sh` to populate `wikidata_id` but previously absent from sources)
- Fix README UN Protocol & Liaison Service link from the Permanent Missions page to the actual UNTERM Excel file URL
- Add Wikidata to README data sources section